### PR TITLE
Internal preparations to add queries to additional databases.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -76,11 +76,17 @@ find_doi <- function (strings) {
 #'
 #' Helper function to convert a timestamp from openretractions.com into a date.
 #'
-#' @param timestamp Numeric timestamp
+#' @param x Numeric timestamp
+#' @param database Character. Database (currently only \code{or})
 #'
 #' @return a Date
 #' @export
 
-get_date <- function(timestamp) {
-  return(as.Date(as.POSIXct(timestamp / 1000, origin='1970-01-01')))
+get_date <- function(x, database = 'or') {
+
+  if (database == 'or') {
+    as.Date(as.POSIXct(x / 1000, origin='1970-01-01'))
+  } else {
+    stop("database '", database, "' not supported.")
+  }
 }


### PR DESCRIPTION
Hi Chris,

this PR proposes some minor changes to the existing functions to extend the internal workflow to additional retraction databases:

- openratractions.com queries are performed by a separate function `query_or()`
- `data.frame`s returned by `retractcheck()` contain a new `database` column
- `get_date()` has a new argument to adapt the functions behavior to different date formats in new databases

With these changes in place, it should be straight forward to add Retraction Watch database queries.