### PR TITLE
Adds new return argument to retractcheck()

### DIFF
--- a/R/retractcheck.R
+++ b/R/retractcheck.R
@@ -23,7 +23,7 @@ NULL
 #'   the order specified in \code{database} until either a correction or
 #'   retraction notice is found or all databases have been queried.
 #'
-#' @return \code{\link{retractcheck}} dataframe
+#' @return \code{\link{retractcheck}} data.frame
 #' @export
 #' @examples \dontrun{
 #'   retractcheck(c('10.1002/job.1787',
@@ -88,6 +88,7 @@ retractcheck <- function (dois, database = c('or', 'rw'), return = 'unique') {
 #' referenced DOIs.
 #'
 #' @param path Path to directory to check
+#' @inheritDotParams retractcheck -dois
 #'
 #' @return \code{\link{retractcheck}} dataframe with filenames
 #' @export
@@ -95,15 +96,16 @@ retractcheck <- function (dois, database = c('or', 'rw'), return = 'unique') {
 #'   retractcheck_dir(path = '.')
 #' }
 
-retractcheck_dir <- function (path) {
+retractcheck_dir <- function (path, ...) {
   res <- NULL
   text <- textreadr::read_dir(path)
 
   for (file in unique(text$document)) {
     dois <- find_doi(text$content[text$document == file])
-
-    updates <- retractcheck(dois)
-    if (!is.null(dois)) res <- rbind(res, data.frame(file, updates))
+    if (!is.null(dois)) {
+      updates <- retractcheck(dois, ...)
+      res <- rbind(res, data.frame(file, updates))
+    }
   }
 
   return(res)
@@ -114,6 +116,7 @@ retractcheck_dir <- function (path) {
 #' Check a DOCX file for retractions.
 #'
 #' @param path Path to DOCX file to check
+#' @inheritDotParams retractcheck -dois
 #'
 #' @return \code{\link{retractcheck}} dataframe without filenames
 #' @export
@@ -121,10 +124,10 @@ retractcheck_dir <- function (path) {
 #'   retractcheck_docx('manuscript.docx')
 #' }
 
-retractcheck_docx <- function (path) {
+retractcheck_docx <- function (path, ...) {
   text <- textreadr::read_docx(path)
   dois <- find_doi(text)
-  res <- retractcheck(dois)
+  res <- retractcheck(dois, ...)
 
   return(res)
 }
@@ -134,6 +137,7 @@ retractcheck_docx <- function (path) {
 #' Check a pdf file for retractions.
 #'
 #' @param path Path to pdf file to check
+#' @inheritDotParams retractcheck -dois
 #'
 #' @return \code{\link{retractcheck}} dataframe without filenames
 #' @export
@@ -141,10 +145,10 @@ retractcheck_docx <- function (path) {
 #'   retractcheck_pdf('manuscript.pdf')
 #' }
 
-retractcheck_pdf <- function (path) {
+retractcheck_pdf <- function (path, ...) {
   text <- textreadr::read_pdf(path)
   dois <- find_doi(text)
-  res <- retractcheck(dois)
+  res <- retractcheck(dois, ...)
 
   return(res)
 }
@@ -154,6 +158,7 @@ retractcheck_pdf <- function (path) {
 #' Check a rtf file for retractions.
 #'
 #' @param path Path to rtf file to check
+#' @inheritDotParams retractcheck -dois
 #'
 #' @return \code{\link{retractcheck}} dataframe without filenames
 #' @export
@@ -161,10 +166,10 @@ retractcheck_pdf <- function (path) {
 #'   retractcheck_rtf('manuscript.rtf')
 #' }
 
-retractcheck_rtf <- function (path) {
+retractcheck_rtf <- function (path, ...) {
   text <- textreadr::read_rtf(path)
   dois <- find_doi(text)
-  res <- retractcheck(dois)
+  res <- retractcheck(dois, ...)
 
   return(res)
 }
@@ -174,6 +179,7 @@ retractcheck_rtf <- function (path) {
 #' Check a html file for retractions.
 #'
 #' @param path Path to html file to check
+#' @inheritDotParams retractcheck -dois
 #'
 #' @return \code{\link{retractcheck}} dataframe without filenames
 #' @export
@@ -181,10 +187,10 @@ retractcheck_rtf <- function (path) {
 #'   retractcheck_html('manuscript.html')
 #' }
 
-retractcheck_html <- function (path) {
+retractcheck_html <- function (path, ...) {
   text <- textreadr::read_html(path)
   dois <- find_doi(text)
-  res <- retractcheck(dois)
+  res <- retractcheck(dois, ...)
 
   return(res)
 }

--- a/R/retractcheck.R
+++ b/R/retractcheck.R
@@ -42,7 +42,7 @@ retractcheck <- function (dois, database = c("or", "rw")) {
   if (sum(df$update_type != "None found") == 0) {
     message('\nHOORAY *<(:)')
     message('None of the DOIs mentioned have indexed retractions or corrections.')
-    return(invisible(NULL))
+    return(invisible(df))
   } else {
     return(df)
   }

--- a/man/retractcheck.Rd
+++ b/man/retractcheck.Rd
@@ -22,7 +22,7 @@ the order specified in \code{database} until either a correction or
 retraction notice is found or all databases have been queried.}
 }
 \value{
-\code{\link{retractcheck}} dataframe
+\code{\link{retractcheck}} data.frame
 }
 \description{
 Using 'Digital Object Identifiers', check for retracted (or otherwise
@@ -39,6 +39,6 @@ and what type of update was made.
 
   retractcheck(c('10.1002/job.1787',
                  '10.1111/j.1365-2044.2012.07128.x'),
-                 return = 'unique')
+                 return = 'all')
 }
 }

--- a/man/retractcheck.Rd
+++ b/man/retractcheck.Rd
@@ -6,15 +6,20 @@
 \alias{retractcheck-package}
 \title{retractcheck: Retraction scanner}
 \usage{
-retractcheck(dois, database = c("or", "rw"))
+retractcheck(dois, database = c("or", "rw"), return = "unique")
 }
 \arguments{
-\item{dois}{Vector of strings containing only DOIs}
+\item{dois}{Character. Vector of containing only DOIs}
 
-\item{database}{Character. Abbreviation of the databases to search
+\item{database}{Character. Abbreviation of the databases to search if
 (\code{or} for openretractions.com and \code{rw} for
 retractiondatabase.com). Note that in the absence of an API,
 searching retractiondatabase.com is rather slow.}
+
+\item{return}{Character. If \code{all}, all databases are queried and all
+results are returned; if \code{unique}, the databases are queried in
+the order specified in \code{database} until either a correction or
+retraction notice is found or all databases have been queried.}
 }
 \value{
 \code{\link{retractcheck}} dataframe
@@ -31,5 +36,9 @@ and what type of update was made.
 \dontrun{
   retractcheck(c('10.1002/job.1787',
                  '10.1111/j.1365-2044.2012.07128.x'))
+
+  retractcheck(c('10.1002/job.1787',
+                 '10.1111/j.1365-2044.2012.07128.x'),
+                 return = 'unique')
 }
 }

--- a/man/retractcheck_dir.Rd
+++ b/man/retractcheck_dir.Rd
@@ -4,10 +4,22 @@
 \alias{retractcheck_dir}
 \title{Check files in directory for retractions}
 \usage{
-retractcheck_dir(path)
+retractcheck_dir(path, ...)
 }
 \arguments{
 \item{path}{Path to directory to check}
+
+\item{...}{Arguments passed on to \code{retractcheck}
+\describe{
+  \item{database}{Character. Abbreviation of the databases to search if
+(\code{or} for openretractions.com and \code{rw} for
+retractiondatabase.com). Note that in the absence of an API,
+searching retractiondatabase.com is rather slow.}
+  \item{return}{Character. If \code{all}, all databases are queried and all
+results are returned; if \code{unique}, the databases are queried in
+the order specified in \code{database} until either a correction or
+retraction notice is found or all databases have been queried.}
+}}
 }
 \value{
 \code{\link{retractcheck}} dataframe with filenames

--- a/man/retractcheck_docx.Rd
+++ b/man/retractcheck_docx.Rd
@@ -4,10 +4,22 @@
 \alias{retractcheck_docx}
 \title{Check docx file for retractions}
 \usage{
-retractcheck_docx(path)
+retractcheck_docx(path, ...)
 }
 \arguments{
 \item{path}{Path to DOCX file to check}
+
+\item{...}{Arguments passed on to \code{retractcheck}
+\describe{
+  \item{database}{Character. Abbreviation of the databases to search if
+(\code{or} for openretractions.com and \code{rw} for
+retractiondatabase.com). Note that in the absence of an API,
+searching retractiondatabase.com is rather slow.}
+  \item{return}{Character. If \code{all}, all databases are queried and all
+results are returned; if \code{unique}, the databases are queried in
+the order specified in \code{database} until either a correction or
+retraction notice is found or all databases have been queried.}
+}}
 }
 \value{
 \code{\link{retractcheck}} dataframe without filenames

--- a/man/retractcheck_html.Rd
+++ b/man/retractcheck_html.Rd
@@ -4,10 +4,22 @@
 \alias{retractcheck_html}
 \title{Check html file for retractions}
 \usage{
-retractcheck_html(path)
+retractcheck_html(path, ...)
 }
 \arguments{
 \item{path}{Path to html file to check}
+
+\item{...}{Arguments passed on to \code{retractcheck}
+\describe{
+  \item{database}{Character. Abbreviation of the databases to search if
+(\code{or} for openretractions.com and \code{rw} for
+retractiondatabase.com). Note that in the absence of an API,
+searching retractiondatabase.com is rather slow.}
+  \item{return}{Character. If \code{all}, all databases are queried and all
+results are returned; if \code{unique}, the databases are queried in
+the order specified in \code{database} until either a correction or
+retraction notice is found or all databases have been queried.}
+}}
 }
 \value{
 \code{\link{retractcheck}} dataframe without filenames

--- a/man/retractcheck_pdf.Rd
+++ b/man/retractcheck_pdf.Rd
@@ -4,10 +4,22 @@
 \alias{retractcheck_pdf}
 \title{Check pdf file for retractions}
 \usage{
-retractcheck_pdf(path)
+retractcheck_pdf(path, ...)
 }
 \arguments{
 \item{path}{Path to pdf file to check}
+
+\item{...}{Arguments passed on to \code{retractcheck}
+\describe{
+  \item{database}{Character. Abbreviation of the databases to search if
+(\code{or} for openretractions.com and \code{rw} for
+retractiondatabase.com). Note that in the absence of an API,
+searching retractiondatabase.com is rather slow.}
+  \item{return}{Character. If \code{all}, all databases are queried and all
+results are returned; if \code{unique}, the databases are queried in
+the order specified in \code{database} until either a correction or
+retraction notice is found or all databases have been queried.}
+}}
 }
 \value{
 \code{\link{retractcheck}} dataframe without filenames

--- a/man/retractcheck_rtf.Rd
+++ b/man/retractcheck_rtf.Rd
@@ -4,10 +4,22 @@
 \alias{retractcheck_rtf}
 \title{Check rtf file for retractions}
 \usage{
-retractcheck_rtf(path)
+retractcheck_rtf(path, ...)
 }
 \arguments{
 \item{path}{Path to rtf file to check}
+
+\item{...}{Arguments passed on to \code{retractcheck}
+\describe{
+  \item{database}{Character. Abbreviation of the databases to search if
+(\code{or} for openretractions.com and \code{rw} for
+retractiondatabase.com). Note that in the absence of an API,
+searching retractiondatabase.com is rather slow.}
+  \item{return}{Character. If \code{all}, all databases are queried and all
+results are returned; if \code{unique}, the databases are queried in
+the order specified in \code{database} until either a correction or
+retraction notice is found or all databases have been queried.}
+}}
 }
 \value{
 \code{\link{retractcheck}} dataframe without filenames


### PR DESCRIPTION
Hi Chris, as suggested in my last pull request, this PR adds a `return` argument to `retractcheck()`. If set to `unique` (default) the databases are queried in the order specified in `database` until one returns a hit. If set to `all` the databases are queried exhaustively. This should things up because Retraction Watch is not queried if Open Retractions already returned a hit.

Despite knowing better this PR makes two other minor change.

1. `retractcheck()` now always (invisibly) returns the results even if there are no hits.
2. All `retractcheck()`-options are made available to wrappers, such as `retractcheck_dir()` via `...`